### PR TITLE
Build docker container on push and release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,40 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image (main branch)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+
+      - name: Build and push Docker image (release)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,13 @@
-
 services:
   dooropener:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: Sloth-on-meth/DoorOpener:v1.2
     environment:
       - DOOROPENER_PORT=${DOOROPENER_PORT:-6532}
       - TZ=${TZ:-UTC}
     ports:
       - "${DOOROPENER_PORT:-6532}:${DOOROPENER_PORT:-6532}"
     volumes:
-      - ./config.ini:/app/config.ini:ro  # Read-only mount
+      - ./config.ini:/app/config.ini:ro # Read-only mount
       - ./logs:/app/logs
     restart: unless-stopped
 
@@ -29,8 +26,6 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.50'
+          cpus: "0.50"
           memory: 256M
     container_name: dooropener
-    
-


### PR DESCRIPTION
This PR adds a automated docker image build as a github action. 
So users can use the pre-build image instead of having to build it on their machine. 

I also adjusted the docker compose file to use the prebuild image